### PR TITLE
chore: onboard stepsecurity and apply security best practice

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -8,13 +8,18 @@ jobs:
   dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: 'adopt'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
         with:
           dependency-graph: generate-and-submit
       - name: Configure local.properties

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -7,11 +7,14 @@ permissions:
 jobs:
   dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1


### PR DESCRIPTION
## Summary
This pull request introduces security and reliability improvements to the GitHub Actions workflow in `.github/workflows/master_build.yml`. The main focus is on hardening the runner environment and ensuring the use of specific, pinned action versions.

## Detail
Security and workflow hardening:

* Added the `step-security/harden-runner` action to block unwanted network egress and enforce a global allowed endpoints policy, increasing the security of the CI environment.
* Explicitly set the `id-token: write` permission for the dependencies job, which is required for certain secure workflows.

Workflow reliability:

* Updated all GitHub Action usages (`actions/checkout`, `actions/setup-java`, and `gradle/gradle-build-action`) to use specific commit SHAs instead of version tags, reducing the risk of supply chain attacks and ensuring reproducible builds.

## Testing

## Documentation

---

**Requested Reviewers:** @mention
